### PR TITLE
Make it compatible with all modules that implement ModuleRCS

### DIFF
--- a/RcsSounds/RcsSounds/RcsSounds.cs
+++ b/RcsSounds/RcsSounds/RcsSounds.cs
@@ -28,7 +28,8 @@ class RcsSounds : PartModule
         get
         {
             if (this._rcsModule == null)
-                this._rcsModule = (ModuleRCS)this.part.Modules["ModuleRCS"];
+                //this._rcsModule = (ModuleRCS)this.part.Modules["ModuleRCS"];
+                this._rcsModule = this.part.FindModuleImplementing<ModuleRCS>();
             return this._rcsModule;
         }
     }


### PR DESCRIPTION
ModuleRCSFX and FNModuleRCSFX  currently will not work because the mods specifically only looks for partModules with the name ModuleRCS. Instead it should look for all partModules that implement the ModuleRCS class, this way it should become universally functional.
